### PR TITLE
Support bootstrap4

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Style          | Description
 `:ol`          | Renders the links in `<li>` elements contained in an outer `<ol>`.
 `:ul`          | Renders the links in `<li>` elements contained in an outer `<ul>`.
 `:bootstrap`   | Renders the links for use in [Twitter Bootstrap](http://getbootstrap.com/).
-`:bootstrap4`  | Renders the links for use in [Bootstrap v4](http://v4-alpha.getbootstrap.com/).
+`:bootstrap4`  | Renders the links for use in [Bootstrap v4](https://getbootstrap.com/).
 `:foundation5` | Renders the links for use in [Foundation 5](http://foundation.zurb.com/).
 
 Or you can build the breadcrumbs manually for full customization; see below.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Style          | Description
 `:ol`          | Renders the links in `<li>` elements contained in an outer `<ol>`.
 `:ul`          | Renders the links in `<li>` elements contained in an outer `<ul>`.
 `:bootstrap`   | Renders the links for use in [Twitter Bootstrap](http://getbootstrap.com/).
+`:bootstrap4`  | Renders the links for use in [Bootstrap v4](http://v4-alpha.getbootstrap.com/).
 `:foundation5` | Renders the links for use in [Foundation 5](http://foundation.zurb.com/).
 
 Or you can build the breadcrumbs manually for full customization; see below.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Option                   | Description                                          
 :semantic                | Whether it should generate [semantic breadcrumbs](http://support.google.com/webmasters/bin/answer.py?hl=en&answer=185417). | False
 :id                      | ID for the breadcrumbs container.                                                                                          | None
 :class                   | CSS class for the breadcrumbs container. Can be set to `nil` for no class.                                                 | `"breadcrumbs"`
+:fragment_class          | CSS class for the fragment link or span. Can be set to `nil` for no class.                                                 | None
 :current_class           | CSS class for the current link or span. Can be set to `nil` for no class.                                                  | `"current"`
 :pretext_class           | CSS class for the pretext, if given. Can be set to `nil` for no class.                                                     | `"pretext"`
 :posttext_class          | CSS class for the posttext, if given. Can be set to `nil` for no class.                                                    | `"posttext"`

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -171,12 +171,12 @@ module Gretel
 
         # Loop through all but the last (current) link and build HTML of the fragments
         fragments = links[0..-2].map do |link|
-          render_fragment(options[:fragment_tag], link.text, link.url, options[:semantic])
+          render_fragment(options[:fragment_tag], link.text, link.url, options[:semantic], fragment_class: options[:fragment_class])
         end
 
         # The current link is handled a little differently, and is only linked if specified in the options
         current_link = links.last
-        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], class: options[:current_class], current_link: current_link.url)
+        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], fragment_class: options[:fragment_class], class: options[:current_class], current_link: current_link.url)
 
         # Build the final HTML
         html_fragments = []
@@ -208,6 +208,9 @@ module Gretel
 
       # Renders semantic fragment HTML.
       def render_semantic_fragment(fragment_tag, text, url, options = {})
+        fragment_class = [options[:fragment_class], options[:class]].join(' ').strip
+        fragment_class = nil if fragment_class.blank?
+
         if fragment_tag
           text = content_tag(:span, text, itemprop: "title")
 
@@ -218,23 +221,26 @@ module Gretel
             text = text + tag(:meta, itemprop: "url", content: current_url)
           end
 
-          content_tag(fragment_tag, text, class: options[:class], itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
+          content_tag(fragment_tag, text, class: fragment_class, itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
         elsif url.present?
-          content_tag(:span, breadcrumb_link_to(content_tag(:span, text, itemprop: "title"), url, class: options[:class], itemprop: "url"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
+          content_tag(:span, breadcrumb_link_to(content_tag(:span, text, itemprop: "title"), url, class: fragment_class, itemprop: "url"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
         else
-          content_tag(:span, content_tag(:span, text, class: options[:class], itemprop: "title"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
+          content_tag(:span, content_tag(:span, text, class: fragment_class, itemprop: "title"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
         end
       end
 
       # Renders regular, non-semantic fragment HTML.
       def render_nonsemantic_fragment(fragment_tag, text, url, options = {})
+        fragment_class = [options[:fragment_class], options[:class]].join(' ').strip
+        fragment_class = nil if fragment_class.blank?
+
         if fragment_tag
           text = breadcrumb_link_to(text, url) if url.present?
-          content_tag(fragment_tag, text, class: options[:class])
+          content_tag(fragment_tag, text, class: fragment_class)
         elsif url.present?
-          breadcrumb_link_to(text, url, class: options[:class])
+          breadcrumb_link_to(text, url, class: fragment_class)
         elsif options[:class].present?
-          content_tag(:span, text, class: options[:class])
+          content_tag(:span, text, class: fragment_class)
         else
           text
         end

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -22,6 +22,7 @@ module Gretel
       ol: { container_tag: :ol, fragment_tag: :li },
       ul: { container_tag: :ul, fragment_tag: :li },
       bootstrap: { container_tag: :ol, fragment_tag: :li, class: "breadcrumb", current_class: "active" },
+      bootstrap4: { container_tag: :ol, fragment_tag: :li, class: "breadcrumb", fragment_class: "breadcrumb-item", current_class: "active" },
       foundation5: { container_tag: :ul, fragment_tag: :li, class: "breadcrumbs", current_class: "current" }
     }
 

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -129,6 +129,12 @@ class HelperMethodsTest < ActionView::TestCase
                  breadcrumbs(class: "custom_class").to_s
   end
 
+  test "custom fragment class" do
+    breadcrumb :basic
+    assert_dom_equal %{<div class="breadcrumbs"><a class="custom_fragment_class" href="/">Home</a> &rsaquo; <span class="custom_fragment_class current">About</span></div>},
+                 breadcrumbs(fragment_class: "custom_fragment_class").to_s
+  end
+
   test "custom current class" do
     breadcrumb :basic
     assert_dom_equal %{<div class="breadcrumbs"><a href="/">Home</a> &rsaquo; <span class="custom_current_class">About</span></div>},

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -364,6 +364,12 @@ class HelperMethodsTest < ActionView::TestCase
                  breadcrumbs(style: :bootstrap).to_s
   end
 
+  test "bootstrap4 style" do
+    breadcrumb :basic
+    assert_dom_equal %{<ol class="breadcrumb"><li class="breadcrumb-item"><a href="/">Home</a></li><li class="breadcrumb-item active">About</li></ol>},
+                 breadcrumbs(style: :bootstrap4).to_s
+  end
+
   test "foundation5 style" do
     breadcrumb :basic
     assert_dom_equal %{<ul class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ul>},


### PR DESCRIPTION
Add class for fragment and bootstrap4 style.
see https://github.com/lassebunk/gretel/pull/73

No need to change from alpha.
* https://getbootstrap.com/docs/4.0/components/breadcrumb/
* https://getbootstrap.com/docs/4.1/components/breadcrumb/

